### PR TITLE
Adding an abs() around the distance.

### DIFF
--- a/src/android/LocationUpdateService.java
+++ b/src/android/LocationUpdateService.java
@@ -483,7 +483,7 @@ public class LocationUpdateService extends Service implements LocationListener {
         if (isDebugging) {
             startTone("beep");
         }
-        float distance = location.distanceTo(stationaryLocation) - stationaryLocation.getAccuracy() - location.getAccuracy();
+	float distance = abs(location.distanceTo(stationaryLocation) - stationaryLocation.getAccuracy() - location.getAccuracy());
         
         if (isDebugging) {
             Toast.makeText(this, "Stationary exit in " + (stationaryRadius-distance) + "m", Toast.LENGTH_LONG).show();


### PR DESCRIPTION
I saw negative distances when I was inside the stationary area, but
moving around within it.. perhaps a few houses over etc. Walking etc.
If I moved farther away, it eventually updated but more becaue it had
a significant update, such as driving miles.
This abs around the distance allows the less-than if statement to work.
Been using it for all day across several cities with great and accurate
updates.
Similar routines over the last few days were highly inaccurate and
behind.
