### PR TITLE
Seconds in Android callback

### DIFF
--- a/src/android/data/sqlite/SQLiteLocationDAO.java
+++ b/src/android/data/sqlite/SQLiteLocationDAO.java
@@ -17,7 +17,7 @@ import com.tenforwardconsulting.cordova.bgloc.data.Location;
 import com.tenforwardconsulting.cordova.bgloc.data.LocationDAO;
 
 public class SQLiteLocationDAO implements LocationDAO {
-	public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm'Z'";
+	public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 	private static final String TAG = "SQLiteLocationDAO";
 	private Context context;
 	


### PR DESCRIPTION
Hi Chris,

I noticed the absence of the seconds of `Recorded_At` property in the Android callback. The seconds were present in the [past](https://github.com/christocracy/cordova-plugin-background-geolocation/blob/11f19d864848746ebfa3cf3fcbe6a6c40f9440fb/src/android/data/sqlite/SQLiteLocationDAO.java) but recently truncated (ab3c2fadcd7a74c78d124780fd61c7a1296d60a4), if there's no specific reason, i'd like to have them back!
