### PR TITLE
Added support for getting locations via javascript for Androids and opting out of posting them to a url

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,7 @@
         <source-file src="src/android/LocationUpdateService.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc" />
         <source-file src="src/android/data/DAOFactory.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data" />
         <source-file src="src/android/data/Location.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data" />
+        <source-file src="src/android/data/LocationSerializer.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data" />
         <source-file src="src/android/data/LocationDAO.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data" />
         <source-file src="src/android/data/sqlite/LocationOpenHelper.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data/sqlite" />
         <source-file src="src/android/data/sqlite/SQLiteLocationDAO.java" target-dir="src/com/tenforwardconsulting/cordova/bgloc/data/sqlite" />

--- a/src/android/LocationUpdateService.java
+++ b/src/android/LocationUpdateService.java
@@ -95,6 +95,7 @@ public class LocationUpdateService extends Service implements LocationListener {
     private String notificationTitle = "Background checking";
     private String notificationText = "ENABLED";
     private Boolean stopOnTerminate;
+    private boolean postLocationsToServer = true;
 
     private ToneGenerator toneGenerator;
 
@@ -180,6 +181,7 @@ public class LocationUpdateService extends Service implements LocationListener {
             isDebugging = Boolean.parseBoolean(intent.getStringExtra("isDebugging"));
             notificationTitle = intent.getStringExtra("notificationTitle");
             notificationText = intent.getStringExtra("notificationText");
+            this.postLocationsToServer = intent.getBooleanExtra("postLocationsToServer", /*defaultValue*/ true);
 
             // Build a Notification required for running service in foreground.
             Intent main = new Intent(this, BackgroundGpsPlugin.class);
@@ -414,7 +416,7 @@ public class LocationUpdateService extends Service implements LocationListener {
         lastLocation = location;
         persistLocation(location);
 
-        if (this.isNetworkConnected()) {
+        if (this.postLocationsToServer && this.isNetworkConnected()) {
             Log.d(TAG, "Scheduling location network post");
             schedulePostLocations();
         } else {

--- a/src/android/data/LocationSerializer.java
+++ b/src/android/data/LocationSerializer.java
@@ -1,0 +1,47 @@
+package com.tenforwardconsulting.cordova.bgloc.data;
+
+import com.tenforwardconsulting.cordova.bgloc.data.Location;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+/**
+ * Helper class to translate Locations into JSON objects.  The JSON objects aim to mimick the https://developer.mozilla.org/en-US/docs/Web/API/Position API.
+ */
+public class LocationSerializer {
+
+    /**
+     * Translate a Location to its JSON representation that mimicks https://developer.mozilla.org/en-US/docs/Web/API/Position.
+     * @param location to translate
+     * @return A JSON representation of the provided Location
+     */
+    public static JSONObject toJSON(Location location) throws JSONException {
+        JSONObject obj = new JSONObject();
+        JSONObject coords = new JSONObject();
+        coords.put("latitude", Double.parseDouble(location.getLatitude()));
+        coords.put("longitude", Double.parseDouble(location.getLongitude()));
+        coords.put("accuracy", Double.parseDouble(location.getAccuracy()));
+        coords.put("speed", Double.parseDouble(location.getSpeed()));
+        coords.put("bearing", Double.parseDouble(location.getBearing()));
+        coords.put("altitude", Double.parseDouble(location.getAltitude()));
+        obj.put("coords", coords);
+        obj.put("timestamp", location.getRecordedAt());
+        return obj;
+    }
+
+
+    /**
+     * Translate an array of Locations to a JSON array where each location mimicks a https://developer.mozilla.org/en-US/docs/Web/API/Position.
+     * @param locations to translate
+     * @return A JSON representation of the provided locations
+     */
+    public static JSONArray toJSON(Location[] locations) throws JSONException {
+        JSONArray jsonLocations = new JSONArray();
+        for (Location location : locations) {
+            JSONObject jsonLocation = LocationSerializer.toJSON(location);
+            jsonLocations.put(jsonLocation);
+        }
+        return jsonLocations;
+    }
+
+}

--- a/www/BackgroundGeoLocation.js
+++ b/www/BackgroundGeoLocation.js
@@ -23,12 +23,13 @@ module.exports = {
             notificationText    = config.notificationText || "ENABLED";
             activityType        = config.activityType || "OTHER";
             stopOnTerminate     = config.stopOnTerminate || false;
+            postLocationsToServer = typeof config.postLocationsToServer !== "undefined" ? config.postLocationsToServer : true;
 
         exec(success || function() {},
              failure || function() {},
              'BackgroundGeoLocation',
              'configure',
-             [params, headers, url, stationaryRadius, distanceFilter, locationTimeout, desiredAccuracy, debug, notificationTitle, notificationText, activityType, stopOnTerminate]
+             [params, headers, url, stationaryRadius, distanceFilter, locationTimeout, desiredAccuracy, debug, notificationTitle, notificationText, activityType, stopOnTerminate, postLocationsToServer]
         );
     },
     start: function(success, failure, config) {
@@ -58,6 +59,24 @@ module.exports = {
             'BackgroundGeoLocation',
             'onPaceChange',
             [isMoving]);
+    },
+    getLocations: function (success, failure, config) {
+        var deleteLocations = typeof config.deleteLocations === "undefined" ? true : config.deleteLocations;
+        exec(function(positions) { if (positions.length && success) { success(positions); } },
+             failure || function() { },
+             'BackgroundGeoLocation',
+             'getLocations',
+             [deleteLocations]);
+    },
+    watch: function (success, failure, config) {
+        window.plugins.backgroundGeoLocation.start(success, failure, config);
+        return window.setInterval(function () {
+            window.plugins.backgroundGeoLocation.getLocations(success, failure, config);
+        }, config.interval || 5000);
+    },
+    clearWatch: function (watchId, success, failure, config) {
+        window.plugins.backgroundGeoLocation.stop(success, failure, config);
+        window.clearTimeout(watchId);
     },
     /**
     * @param {Integer} stationaryRadius


### PR DESCRIPTION
Hey @christocracy.  I work at [Hurdlr](https://www.linkedin.com/company/9214326?trk=prof-exp-company-name).  We build a mobile app with Cordova.  We're looking to use parts of your open source library to implement our mileage tracker on Android phones.  However, our use case requires a bit different functionality from what your library supports.  Specifically, we require:

1. The ability to access location points in javascript without posting to the server on an Android phone.
2. More aggressive location tracking that unfortunately uses more battery but is more accurate.

I've implemented the first feature in this branch.  It attempts to mimic ```navigator.geolocation.watchPosition``` as best it can.  This branch supports opting out of posting data to the server via the postLocationsToServer parameter.  And it supports accessing locations via javascript with the watch, clearWatch, and getLocations.  Currently this pull request isn't ready to be merged because it doesn't support ios nor wp8, and the data is presented in a different format than locations are in other areas of the library.

Despite the inconsistencies, I created this pull request because I thought you may be interested in integrating a more polished version of this feature.  I'd be happy to work with you to polish this pull request so it can be integrated in the library if you think it would be valuable.  I'm curious to hear your feedback. 

I've implemented the second feature in https://github.com/steaks/cordova-plugin-background-geolocation/tree/traxBackgroundGeoLocation.  I think that branch differs too much from the intention of the project to merge.