### PR TITLE
Update CDVBackgroundGeoLocation.m

### DIFF
--- a/src/ios/CDVBackgroundGeoLocation.m
+++ b/src/ios/CDVBackgroundGeoLocation.m
@@ -762,11 +762,7 @@
  * Might be desirable in certain apps.
  */
 - (void)applicationWillTerminate:(UIApplication *)application {
-    [locationManager stopMonitoringSignificantLocationChanges];
-    [locationManager stopUpdatingLocation];
-    if (stationaryRegion != nil) {
-        [locationManager stopMonitoringForRegion:stationaryRegion];
-    }
+    
 }
 
 - (void)dealloc


### PR DESCRIPTION
Do not stopMonitoringSignificantLocationChanges or stopMonitoringForRegion since this these events can trigger the app to restart after a device reboot.

Thanks @echojuno for pointing this out.