### PR TITLE
Changed the plugin.xml dependencies to the new NPM-based plugin syntax

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,8 +13,8 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <dependency id="org.apache.cordova.geolocation" />
-    <dependency id="org.apache.cordova.dialogs" />
+    <dependency id="cordova-plugin-geolocation" />
+    <dependency id="cordova-plugin-dialogs" />
 
     <js-module src="www/BackgroundGeoLocation.js" name="BackgroundGeoLocation">
         <clobbers target="plugins.backgroundGeoLocation" />


### PR DESCRIPTION
As of cordova@5.0.0, cordova supported npm-hosted plugins and have moved their own plugins to npm. When you add this plugin to a cordova project, the dependencies are set to org.apache.cordova.dialogs and org.apache.cordova.geolocation which adds the older-style, github hosted plugins (and as plugin versions progress, this method will not pick up the new versions that are released).

Please can you consider this pull request for inclusion in the project to support the new npm-style plugin syntax.

More information can be found [here](http://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html).