### PR TITLE
Cordova 5 seems to clobber my clobbers window.plugins.backgroundGeoLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Follows the [Cordova Plugin spec](https://github.com/apache/cordova-plugman/blob
 This plugin leverages Cordova/PhoneGap's [require/define functionality used for plugins](http://simonmacdonald.blogspot.ca/2012/08/so-you-wanna-write-phonegap-200-android.html).
 
 ## Using the plugin ##
-The plugin creates the object `window.plugins.backgroundGeoLocation` with the methods
+The plugin creates the object `window.BackgroundGeolocation` with the methods
 
   `configure(success, fail, option)`,
 
@@ -59,7 +59,7 @@ A full example could be:
         console.log('Location from Phonegap');
     });
 
-    var bgGeo = window.plugins.backgroundGeoLocation;
+    var bgGeo = window.BackgroundGeolocation;
 
     /**
     * This would be your own callback for Ajax-requests after POSTing background geolocation to your server.

--- a/example/SampleApp/www/js/index.js
+++ b/example/SampleApp/www/js/index.js
@@ -134,7 +134,7 @@ var app = {
     },
     configureBackgroundGeoLocation: function() {
         var fgGeo = window.navigator.geolocation,
-            bgGeo = window.plugins.backgroundGeoLocation;
+            bgGeo = window.BackgroundGeolocation;
 
         app.onClickHome();
 
@@ -226,7 +226,7 @@ var app = {
         });
     },
     onClickChangePace: function(value) {
-        var bgGeo   = window.plugins.backgroundGeoLocation,
+        var bgGeo   = window.BackgroundGeolocation,
             btnPace = app.btnPace;
 
         btnPace.removeClass('btn-success');
@@ -254,7 +254,7 @@ var app = {
         app.path = undefined;
     },
     onClickToggleEnabled: function(value) {
-        var bgGeo       = window.plugins.backgroundGeoLocation,
+        var bgGeo       = window.BackgroundGeolocation,
             btnEnabled  = app.btnEnabled,
             isEnabled   = ENV.toggle('enabled');
         

--- a/example/www/js/index.js
+++ b/example/www/js/index.js
@@ -35,7 +35,7 @@ var app = {
     onDeviceReady: function() {
         app.receivedEvent('deviceready');
 
-        if (window.plugins.backgroundGeoLocation) {
+        if (window.BackgroundGeolocation) {
             app.configureBackgroundGeoLocation();
         }
 
@@ -58,7 +58,7 @@ var app = {
             console.log('Location from Phonegap');
         });
 
-        var bgGeo = window.plugins.backgroundGeoLocation;
+        var bgGeo = window.BackgroundGeolocation;
 
         /**
         * This would be your own callback for Ajax-requests after POSTing background geolocation to your server.

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
     <dependency id="cordova-plugin-dialogs" />
 
     <js-module src="www/BackgroundGeoLocation.js" name="BackgroundGeoLocation">
-        <clobbers target="plugins.backgroundGeoLocation" />
+        <clobbers target="window.BackgroundGeolocation" />
     </js-module>
 
     <!-- android -->


### PR DESCRIPTION
**Breaking change**.  This PR changes the javascript reference `window.plugins.backgroundGeoLocation` to `window.BackgroundGeolocation` due to reported issues with Cordova 5 overwriting `window.plugins`.

Update your code as noted in README.